### PR TITLE
update certbot version and change to renew command

### DIFF
--- a/ssl/renew_all_certs.sh
+++ b/ssl/renew_all_certs.sh
@@ -7,6 +7,9 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 echo "renew for domains $DOMAINS"
 echo "store challege in $SERVE_DIR"
 
-mkdir -p $SERVE_DIR && $DIR/../letsencrypt/letsencrypt-auto --renew certonly --server $SERVER -a webroot --webroot-path=$SERVE_DIR --agree-tos $DOMAINS
+#mkdir -p $SERVE_DIR && $DIR/../letsencrypt/letsencrypt-auto --renew certonly --server $SERVER -a webroot --webroot-path=$SERVE_DIR --agree-tos $DOMAINS
+
+# when we apply certificates, just renew is OK
+mkdir -p $SERVE_DIR && $DIR/../letsencrypt/letsencrypt-auto renew
 
 /usr/sbin/nginx -s reload


### PR DESCRIPTION
When we have applied certificates, just **renew** is OK.
The certbot has generated configuration for us in folder **/etc/letsencrypt/renewal**
The option --renew is ambiguous. The option --renew-by-default or --renew-hook is right.
